### PR TITLE
프론트엔드 코드 개선 및 blog_ids 다중 필터 지원

### DIFF
--- a/fastapi/app/models/post.py
+++ b/fastapi/app/models/post.py
@@ -35,7 +35,7 @@ class Post(Base):
     normalized_url = Column(String(1000), unique=True, index=True, comment="정규화된 URL (쿼리 파라미터 제거)")
 
     # 블로그 관계
-    blog_id = Column(Integer, ForeignKey("blogs.id"), nullable=False, index=True, comment="블로그 ID")
+    blog_id = Column(Integer, ForeignKey("blogs.id", ondelete="CASCADE"), nullable=False, index=True, comment="블로그 ID")
     blog = relationship("Blog", backref="posts")
 
     # 발행 정보

--- a/fastapi/app/services/domain/post_service.py
+++ b/fastapi/app/services/domain/post_service.py
@@ -51,7 +51,7 @@ class PostService:
         self,
         skip: int = 0,
         limit: int = 20,
-        blog_id: Optional[int] = None,
+        blog_ids: Optional[List[int]] = None,
         include_blog: bool = False
     ) -> tuple[List[Post], int]:
         """
@@ -60,18 +60,18 @@ class PostService:
         Args:
             skip: 건너뛸 개수
             limit: 최대 조회 개수
-            blog_id: 특정 블로그 필터링
+            blog_ids: 블로그 ID 필터 리스트 (optional)
             include_blog: 블로그 정보 포함 여부
 
         Returns:
             (포스트 리스트, 전체 개수)
         """
-        logger.info(f"Fetching posts: skip={skip}, limit={limit}, blog_id={blog_id}")
+        logger.info(f"Fetching posts: skip={skip}, limit={limit}, blog_ids={blog_ids}")
 
         posts, total = await self.repository.get_all(
             skip=skip,
             limit=limit,
-            blog_id=blog_id,
+            blog_ids=blog_ids,
             include_blog=include_blog
         )
 
@@ -82,7 +82,8 @@ class PostService:
         self,
         query: str,
         limit: int = 20,
-        offset: int = 0
+        offset: int = 0,
+        blog_ids: Optional[List[int]] = None
     ) -> tuple[List[tuple[Post, float]], int]:
         """
         포스트 전문 검색 (PostgreSQL Full-Text Search)
@@ -91,17 +92,19 @@ class PostService:
             query: 검색어
             limit: 최대 결과 개수
             offset: 건너뛸 개수
+            blog_ids: 블로그 ID 필터 리스트 (optional)
 
         Returns:
             ((Post, rank) 튜플 리스트 (blog relationship 포함), 전체 개수)
         """
-        logger.info(f"Searching posts: query='{query}', limit={limit}, offset={offset}")
+        logger.info(f"Searching posts: query='{query}', limit={limit}, offset={offset}, blog_ids={blog_ids}")
 
         # Repository를 통해 검색 (ORM 모델 + rank 반환)
         posts_with_rank, total = await self.repository.search_fulltext(
             search_query=query,
             limit=limit,
-            offset=offset
+            offset=offset,
+            blog_ids=blog_ids
         )
 
         logger.info(f"Found {len(posts_with_rank)} posts out of {total} total for query '{query}'")

--- a/fastapi/app/services/workers/content_extractor.py
+++ b/fastapi/app/services/workers/content_extractor.py
@@ -176,13 +176,13 @@ class ContentExtractor:
         Returns:
             추출 결과 또는 None (실패)
         """
+        browser = None
         try:
             async with async_playwright() as p:
                 browser = await p.chromium.launch(headless=True)
                 page = await browser.new_page()
                 await page.goto(url, wait_until='networkidle', timeout=self.playwright_timeout)
                 html_content = await page.content()
-                await browser.close()
 
                 html_length = len(html_content)
 
@@ -212,6 +212,12 @@ class ContentExtractor:
         except Exception as e:
             logger.error(f"Step 2 failed for {url[:50]}...: {e}", exc_info=True)
             return None
+        finally:
+            if browser:
+                try:
+                    await browser.close()
+                except Exception as close_error:
+                    logger.warning(f"Failed to close browser: {close_error}")
 
     async def extract(self, url: str, use_proxy: bool = True) -> Optional[Dict[str, Any]]:
         """

--- a/frontend/src/app/_components/home-client.tsx
+++ b/frontend/src/app/_components/home-client.tsx
@@ -27,9 +27,10 @@ export function HomeClient({
     reset,
   } = useUrlState();
 
-  // 모든 필터 상태를 URL 상태와 동기화
+  // 검색 입력 중간 상태 (URL에는 엔터/검색 버튼 시에만 반영)
   const [searchQuery, setSearchQuery] = useState(urlState.keyword || '');
-  const [selectedBlogs, setSelectedBlogs] = useState<number[]>(urlState.blogIds || []);
+
+  // selectedBlogs는 urlState.blogIds를 직접 사용 (상태 중복 제거)
 
   // 서버에서 받은 초기 데이터를 우선 사용하고, 필요시 클라이언트에서 추가 fetch
   const { data: blogs = initialBlogs } = useBlogs(initialBlogs);
@@ -69,20 +70,16 @@ export function HomeClient({
 
   const handleReset = () => {
     setSearchQuery('');
-    setSelectedBlogs([]);
-
     reset();
   };
 
-  // URL 상태와 로컬 상태 동기화
+  // URL keyword 변경 시 검색 입력 필드 동기화
   useEffect(() => {
     setSearchQuery(urlState.keyword || '');
-    setSelectedBlogs(urlState.blogIds || []);
-  }, [urlState]);
+  }, [urlState.keyword]);
 
-  // 필터 변경 시 URL 업데이트
+  // 블로그 필터 변경 시 URL 직접 업데이트
   const handleBlogChange = (blogIds: number[]) => {
-    setSelectedBlogs(blogIds);
     setBlogIds(blogIds);
   };
 
@@ -100,7 +97,7 @@ export function HomeClient({
 
       <PostFilters
         blogs={blogs}
-        selectedBlogs={selectedBlogs}
+        selectedBlogs={urlState.blogIds || []}
         onBlogChange={handleBlogChange}
       />
 

--- a/frontend/src/app/admin/blogs/page.tsx
+++ b/frontend/src/app/admin/blogs/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import { Blog } from '@/types';
+import { Blog, BlogType } from '@/types';
 import { RefreshCw, Globe, Activity, Calendar, Plus, Download, Trash2, Edit } from 'lucide-react';
 import { BlogModal } from '@/components/blogs/blog-modal';
 import { useCreateBlog, useUpdateBlog, useDeleteBlog } from '@/lib/hooks/use-blogs';
 import { useAdminBlogs } from '@/lib/hooks/use-admin';
 import { adminApi } from '@/lib/api/endpoints/admin';
 import type { BlogFormData } from '@/lib/utils/validation';
+import { logger } from '@/lib/config';
 
 export default function AdminBlogsPage() {
   const { data: blogsData, isLoading, refetch } = useAdminBlogs(0, 100);
@@ -25,7 +26,7 @@ export default function AdminBlogsPage() {
   const handleCreateBlog = async (data: BlogFormData) => {
     await createBlogMutation.mutateAsync({
       ...data,
-      blog_type: 'COMPANY',
+      blog_type: BlogType.COMPANY,
     });
     setIsAddModalOpen(false);
   };
@@ -49,7 +50,7 @@ export default function AdminBlogsPage() {
       refetch();
     } catch (error) {
       alert('전체 재크롤링 요청 중 오류가 발생했습니다.');
-      console.error('Error triggering all recrawl:', error);
+      logger.error('Error triggering all recrawl:', error);
     } finally {
       setTriggering(null);
     }
@@ -65,7 +66,7 @@ export default function AdminBlogsPage() {
       refetch();
     } catch (error) {
       alert('RSS 수집 요청 중 오류가 발생했습니다.');
-      console.error('Error triggering blog recrawl:', error);
+      logger.error('Error triggering blog recrawl:', error);
     } finally {
       setTriggering(null);
     }
@@ -79,7 +80,7 @@ export default function AdminBlogsPage() {
       alert('블로그가 삭제되었습니다.');
     } catch (error) {
       alert('블로그 삭제 중 오류가 발생했습니다.');
-      console.error('Error deleting blog:', error);
+      logger.error('Error deleting blog:', error);
     }
   };
 
@@ -99,7 +100,7 @@ export default function AdminBlogsPage() {
       }
     } catch (error) {
       alert('본문 추출 중 오류가 발생했습니다.');
-      console.error('Error processing blog posts:', error);
+      logger.error('Error processing blog posts:', error);
     } finally {
       setProcessingBlogId(null);
     }
@@ -178,7 +179,7 @@ export default function AdminBlogsPage() {
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {blogs.map((blog) => {
-                const postCount = blog.post_count ?? blog.postCount ?? 0;
+                const postCount = blog.post_count ?? 0;
                 return (
                   <tr key={blog.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4">

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { FileText, Globe, TrendingUp, Clock, Activity, Play, RotateCcw, Zap } fr
 import Link from 'next/link';
 import { useSchedulerStats, useCollectAllRSS, useProcessContent, useRetryFailed } from '@/lib/hooks/use-admin';
 import { PostStatus, BlogStatus } from '@/types';
+import { logger } from '@/lib/config';
 
 export default function AdminDashboard() {
   // Use React Query hooks
@@ -37,7 +38,7 @@ export default function AdminDashboard() {
       alert(`RSS 수집 완료!\n- 처리된 블로그: ${result.summary.blogs_processed}개\n- 새 포스트: ${result.summary.new_posts}개\n- 중복 스킵: ${result.summary.skipped_duplicates}개`);
     } catch (error) {
       alert('RSS 수집 중 오류가 발생했습니다.');
-      console.error('Error collecting RSS:', error);
+      logger.error('Error collecting RSS:', error);
     }
   };
 
@@ -49,7 +50,7 @@ export default function AdminDashboard() {
       alert(`본문 추출 완료!\n- 처리된 포스트: ${result.summary.total_processed}개\n- 성공: ${result.summary.completed}개\n- 실패: ${result.summary.failed}개`);
     } catch (error) {
       alert('본문 추출 중 오류가 발생했습니다.');
-      console.error('Error processing content:', error);
+      logger.error('Error processing content:', error);
     }
   };
 
@@ -61,7 +62,7 @@ export default function AdminDashboard() {
       alert(`재시도 완료!\n- 처리된 포스트: ${result.summary.total_processed}개\n- 성공: ${result.summary.completed}개\n- 실패: ${result.summary.failed}개`);
     } catch (error) {
       alert('재시도 중 오류가 발생했습니다.');
-      console.error('Error retrying failed posts:', error);
+      logger.error('Error retrying failed posts:', error);
     }
   };
 

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { adminAuth } from '@/lib/utils/admin-auth';
 import { Zap, LayoutDashboard, FileText, Globe, LogOut } from 'lucide-react';
 import Link from 'next/link';
@@ -9,6 +10,7 @@ import Link from 'next/link';
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -20,6 +22,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   }, [pathname, router]);
 
   const handleLogout = () => {
+    // React Query 캐시 정리 후 로그아웃
+    queryClient.clear();
     adminAuth.logout();
   };
 

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -6,6 +6,7 @@ import { Zap } from 'lucide-react';
 import { postsApi } from '@/lib/api/endpoints/posts';
 import { adminAuth } from '@/lib/utils/admin-auth';
 import { AxiosError } from 'axios';
+import { logger } from '@/lib/config';
 
 export default function AdminLoginPage() {
   const [credentials, setCredentials] = useState({ username: '', password: '' });
@@ -39,7 +40,7 @@ export default function AdminLoginPage() {
       } else {
         setError('로그인 중 오류가 발생했습니다.');
       }
-      console.error('Login error:', error);
+      logger.error('Login error:', error);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/app/admin/posts/page.tsx
+++ b/frontend/src/app/admin/posts/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Search, Filter, RefreshCw, FileText, Calendar, User, ExternalLink, Trash2, Download } from 'lucide-react';
 import { usePosts, useSearchPosts, useDeletePost } from '@/lib/hooks/use-posts';
 import { useProcessPost } from '@/lib/hooks/use-admin';
+import { logger } from '@/lib/config';
 
 export default function AdminPostsPage() {
   const [currentPage, setCurrentPage] = useState(0);
@@ -88,7 +89,7 @@ export default function AdminPostsPage() {
       }
     } catch (error) {
       alert('본문 추출 중 오류가 발생했습니다.');
-      console.error('Error processing post:', error);
+      logger.error('Error processing post:', error);
     } finally {
       setProcessingPostId(null);
     }
@@ -102,7 +103,7 @@ export default function AdminPostsPage() {
       alert('포스트가 삭제되었습니다.');
     } catch (error) {
       alert('포스트 삭제 중 오류가 발생했습니다.');
-      console.error('Error deleting post:', error);
+      logger.error('Error deleting post:', error);
     }
   };
 

--- a/frontend/src/app/posts/[id]/page.tsx
+++ b/frontend/src/app/posts/[id]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${post.title} - ${post.blog.company}`,
     description,
-    keywords: post.tags || [],
+    keywords: post.keywords || [],
     authors: post.author ? [{ name: post.author }] : undefined,
     openGraph: {
       title: post.title,
@@ -43,7 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       locale: 'ko_KR',
       publishedTime: post.published_at,
       authors: post.author ? [post.author] : undefined,
-      tags: post.tags || [],
+      tags: post.keywords || [],
       images: [
         {
           url: post.blog.logo_url || '/og-image.svg',

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -22,36 +22,60 @@ export default function PostCard({ post }: PostCardProps) {
     router.push(`/posts/${post.id}`);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
   const handleCompanyClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 이벤트 전파 방지
-    setBlogIds([post.blog?.id ?? 0]); // 해당 회사의 블로그로 필터링
+    e.stopPropagation();
+    setBlogIds([post.blog?.id ?? 0]);
+  };
+
+  const handleCompanyKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      setBlogIds([post.blog?.id ?? 0]);
+    }
   };
 
   const publishedDate = new Date(post.published_at);
   const isRecent = Date.now() - publishedDate.getTime() < 24 * 60 * 60 * 1000; // 24 hours;
 
   return (
-    <article 
+    <article
+      role="button"
+      tabIndex={0}
       onClick={handleClick}
-      className="group relative bg-white rounded-lg border border-slate-200 p-4 
-                 hover:shadow-md hover:shadow-slate-200/50 hover:border-slate-300 
-                 transition-all duration-200 cursor-pointer"
+      onKeyDown={handleKeyDown}
+      aria-label={`${post.blog?.company}: ${post.title}`}
+      className="group relative bg-white rounded-lg border border-slate-200 p-4
+                 hover:shadow-md hover:shadow-slate-200/50 hover:border-slate-300
+                 transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
     >
       <div className="flex items-start space-x-4">
         {/* Left side - Company Logo and Info */}
         <div className="flex-shrink-0 flex flex-col items-center">
-          <div 
+          <div
+            role="button"
+            tabIndex={0}
             onClick={handleCompanyClick}
-            className="w-6 h-6 
-                      flex items-center justify-center mb-2 cursor-pointer 
-                      overflow-hidden"
+            onKeyDown={handleCompanyKeyDown}
+            aria-label={`${post.blog?.company} 블로그 필터`}
+            className="w-6 h-6
+                      flex items-center justify-center mb-2 cursor-pointer
+                      overflow-hidden focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
           >
             {post.blog?.logo_url && !logoError ? (
-              <Image 
+              <Image
                 src={post.blog?.logo_url}
                 alt={`${post.blog?.company} logo`}
                 width={24}
                 height={24}
+                loading="lazy"
                 className="w-full h-full object-contain"
                 onError={() => setLogoError(true)}
               />
@@ -64,10 +88,14 @@ export default function PostCard({ post }: PostCardProps) {
             )}
           </div>
           <div className="text-center">
-            <div 
+            <div
+              role="button"
+              tabIndex={0}
               onClick={handleCompanyClick}
-              className="text-xs font-medium text-slate-700 truncate w-16 cursor-pointer hover:text-blue-600 
-                        transition-colors duration-200"
+              onKeyDown={handleCompanyKeyDown}
+              aria-label={`${post.blog?.company} 블로그 필터`}
+              className="text-xs font-medium text-slate-700 truncate w-16 cursor-pointer hover:text-blue-600
+                        transition-colors duration-200 focus:outline-none focus:text-blue-600"
             >
               {post.blog?.company}
             </div>

--- a/frontend/src/components/forms/blog-form.tsx
+++ b/frontend/src/components/forms/blog-form.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { blogFormSchema, type BlogFormData } from '@/lib/utils/validation';
-import type { Blog } from '@/types';
+import { BlogType, type Blog } from '@/types';
 
 interface BlogFormProps {
   blog?: Blog;
@@ -31,7 +31,7 @@ export function BlogForm({ blog, onSubmit, onCancel, isLoading = false }: BlogFo
           site_url: blog.site_url,
           logo_url: blog.logo_url || '',
           description: blog.description || '',
-          blog_type: blog.blog_type || 'COMPANY',
+          blog_type: blog.blog_type || BlogType.COMPANY,
         }
       : {
           name: '',
@@ -40,7 +40,7 @@ export function BlogForm({ blog, onSubmit, onCancel, isLoading = false }: BlogFo
           site_url: '',
           logo_url: '',
           description: '',
-          blog_type: 'COMPANY',
+          blog_type: BlogType.COMPANY,
         },
   });
 

--- a/frontend/src/components/posts/blog-filter.tsx
+++ b/frontend/src/components/posts/blog-filter.tsx
@@ -35,22 +35,38 @@ const CustomCheckbox = ({ checked, onChange, disabled = false }: CheckboxProps) 
 
 interface CheckboxItemProps {
   checked: boolean;
-  onChange: (e: React.MouseEvent) => void;
+  onChange: () => void;
   children: React.ReactNode;
   disabled?: boolean;
+  label: string;
 }
 
-const CheckboxItem = ({ checked, onChange, children, disabled = false }: CheckboxItemProps) => (
-  <div
-    onClick={onChange}
-    className={`flex items-center p-3 rounded-lg cursor-pointer group transition-all duration-150 ${
-      checked ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-slate-50'
-    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-  >
-    <CustomCheckbox checked={checked} onChange={onChange} disabled={disabled} />
-    <div className="ml-3 flex items-center space-x-2 flex-1 min-w-0">{children}</div>
-  </div>
-);
+const CheckboxItem = ({ checked, onChange, children, disabled = false, label }: CheckboxItemProps) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (!disabled) onChange();
+    }
+  };
+
+  return (
+    <div
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      tabIndex={disabled ? -1 : 0}
+      onClick={() => !disabled && onChange()}
+      onKeyDown={handleKeyDown}
+      className={`flex items-center p-3 rounded-lg cursor-pointer group transition-all duration-150
+        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 ${
+        checked ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-slate-50'
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      <CustomCheckbox checked={checked} onChange={() => onChange()} disabled={disabled} />
+      <div className="ml-3 flex items-center space-x-2 flex-1 min-w-0">{children}</div>
+    </div>
+  );
+};
 
 export function BlogFilter({ blogs, selectedBlogs, searchTerm, onBlogToggle }: BlogFilterProps) {
   const filteredBlogs = useMemo(() => {
@@ -90,17 +106,15 @@ export function BlogFilter({ blogs, selectedBlogs, searchTerm, onBlogToggle }: B
   return (
     <div className="space-y-1">
       {filteredBlogs.map((blog) => {
-        const postCount = blog.post_count ?? blog.postCount ?? 0;
+        const postCount = blog.post_count ?? 0;
         const latestDate = blog.latest_post_published_at;
 
         return (
           <CheckboxItem
             key={blog.id}
             checked={selectedBlogs.includes(blog.id)}
-            onChange={(e) => {
-              e.stopPropagation();
-              onBlogToggle(blog.id);
-            }}
+            onChange={() => onBlogToggle(blog.id)}
+            label={`${blog.name} 블로그 선택`}
           >
             <div className="flex items-center gap-3 min-w-0 flex-1">
               {blog.logo_url ? (
@@ -109,6 +123,7 @@ export function BlogFilter({ blogs, selectedBlogs, searchTerm, onBlogToggle }: B
                   alt={`${blog.name} logo`}
                   width={32}
                   height={32}
+                  loading="lazy"
                   className="rounded-lg object-cover flex-shrink-0"
                 />
               ) : (

--- a/frontend/src/hooks/useInfinitePosts.ts
+++ b/frontend/src/hooks/useInfinitePosts.ts
@@ -35,10 +35,11 @@ export function useInfinitePosts(
     queryKey,
     queryFn: async ({ pageParam = 0 }) => {
       if (isKeywordSearch) {
-        // 키워드 검색 API 사용
+        // 키워드 검색 API 사용 (블로그 필터 포함)
         const result = await postsApi.search(searchRequest.keyword!, {
           limit: pageSize,
           offset: pageParam * pageSize,
+          blog_ids: searchRequest.blogIds, // 여러 블로그 ID 지원
         });
 
         // FastAPI 응답을 Spring Boot 형식으로 변환
@@ -56,7 +57,7 @@ export function useInfinitePosts(
         const result = await postsApi.getAll({
           skip: pageParam * pageSize,
           limit: pageSize,
-          blog_id: searchRequest.blogIds?.[0], // 첫 번째 블로그 ID만 사용
+          blog_ids: searchRequest.blogIds, // 여러 블로그 ID 지원
         });
 
         // FastAPI 응답을 Spring Boot 형식으로 변환

--- a/frontend/src/hooks/useSummaryStream.ts
+++ b/frontend/src/hooks/useSummaryStream.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { API_URL } from '@/lib/config';
+import { API_URL, logger } from '@/lib/config';
 
 interface SummaryState {
   excerpt: string;
@@ -86,13 +86,13 @@ export function useSummaryStream(postId: number) {
             break;
         }
       } catch (e) {
-        console.error('JSON 파싱 오류:', e);
+        logger.error('JSON 파싱 오류:', e);
       }
     };
 
     // 에러 처리
     eventSource.onerror = (error) => {
-      console.error('SSE 오류:', error);
+      logger.error('SSE 오류:', error);
       setState(prev => ({
         ...prev,
         status: 'error',

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,9 +1,7 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
-import { API_URL, IS_DEVELOPMENT } from '@/lib/config';
+import { API_URL, logger } from '@/lib/config';
 
-if (IS_DEVELOPMENT) {
-  console.log('API_BASE_URL:', API_URL);
-}
+logger.log('API_BASE_URL:', API_URL);
 
 // Public API client (no authentication)
 export const apiClient: AxiosInstance = axios.create({
@@ -69,22 +67,3 @@ export const handleApiError = (error: unknown): ApiError => {
   };
 };
 
-// Auth utilities
-export const adminAuth = {
-  isLoggedIn: (): boolean => {
-    if (typeof window === 'undefined') return false;
-    return !!localStorage.getItem('admin-auth');
-  },
-
-  logout: (): void => {
-    if (typeof window !== 'undefined') {
-      localStorage.removeItem('admin-auth');
-      window.location.href = '/admin/login';
-    }
-  },
-
-  getAuth: (): string | null => {
-    if (typeof window === 'undefined') return null;
-    return localStorage.getItem('admin-auth');
-  },
-};

--- a/frontend/src/lib/api/endpoints/blogs.ts
+++ b/frontend/src/lib/api/endpoints/blogs.ts
@@ -1,5 +1,5 @@
 import { apiClient, adminClient } from '../client';
-import type { Blog, BlogListResponse } from '@/types';
+import type { Blog, BlogListResponse, BlogType } from '@/types';
 
 export interface CreateBlogDto {
   name: string;
@@ -8,7 +8,7 @@ export interface CreateBlogDto {
   site_url: string;
   logo_url?: string;
   description?: string;
-  blog_type?: string;
+  blog_type?: BlogType;
 }
 
 export const blogsApi = {

--- a/frontend/src/lib/api/endpoints/posts.ts
+++ b/frontend/src/lib/api/endpoints/posts.ts
@@ -6,16 +6,23 @@ export const postsApi = {
   getAll: async (params?: {
     skip?: number;
     limit?: number;
-    blog_id?: number;
+    blog_ids?: number[];
   }): Promise<PostListResponse> =>
-    apiClient.get('/api/v1/posts', { params }).then((res) => res.data),
+    apiClient
+      .get('/api/v1/posts', {
+        params,
+        paramsSerializer: {
+          indexes: null, // blog_ids=1&blog_ids=2 형식으로 직렬화
+        },
+      })
+      .then((res) => res.data),
 
   getById: async (id: number): Promise<Post> =>
     apiClient.get(`/api/v1/posts/${id}`).then((res) => res.data),
 
   search: async (
     keyword: string,
-    params?: { limit?: number; offset?: number }
+    params?: { limit?: number; offset?: number; blog_ids?: number[] }
   ): Promise<SearchResultResponse> =>
     apiClient
       .get('/api/v1/posts/search', {
@@ -23,6 +30,10 @@ export const postsApi = {
           q: keyword,
           limit: params?.limit || 20,
           offset: params?.offset || 0,
+          blog_ids: params?.blog_ids,
+        },
+        paramsSerializer: {
+          indexes: null, // blog_ids=1&blog_ids=2 형식으로 직렬화
         },
       })
       .then((res) => res.data),

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -54,3 +54,24 @@ export function getAbsoluteUrl(path: string): string {
 export function getPostUrl(postId: number): string {
   return getAbsoluteUrl(`posts/${postId}`);
 }
+
+/**
+ * Logger utility - only logs in development mode
+ */
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (IS_DEVELOPMENT) {
+      console.log(...args);
+    }
+  },
+  error: (message: string, error?: unknown) => {
+    if (IS_DEVELOPMENT) {
+      console.error(message, error);
+    }
+  },
+  warn: (...args: unknown[]) => {
+    if (IS_DEVELOPMENT) {
+      console.warn(...args);
+    }
+  },
+};

--- a/frontend/src/lib/utils/validation.ts
+++ b/frontend/src/lib/utils/validation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BlogType } from '@/types';
 
 export const blogFormSchema = z.object({
   name: z.string().min(1, '블로그 이름은 필수입니다.'),
@@ -17,7 +18,7 @@ export const blogFormSchema = z.object({
     .optional()
     .or(z.literal('')),
   description: z.string().optional(),
-  blog_type: z.string().optional(),
+  blog_type: z.nativeEnum(BlogType).optional(),
 });
 
 export type BlogFormData = z.infer<typeof blogFormSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,13 +25,12 @@ export interface Blog {
   site_url: string;
   description?: string;
   logo_url?: string;
-  status: string;
-  blog_type?: string;
+  status: BlogStatus;
+  blog_type?: BlogType;
   created_at: string;
   updated_at: string;
   last_crawled_at?: string;
   failure_count?: number;
-  postCount?: number;
   post_count?: number;
   latest_post_published_at?: string;
 }
@@ -49,10 +48,9 @@ export interface Post {
   blog_id: number;
   blog: BlogInfo;
   keywords?: string[];
-  tags?: string[] | null;
-  categories?: string[] | null;
-  totalContent?: string;
-  summaryContent?: string;
+  status?: PostStatus;
+  retry_count?: number;
+  error_message?: string;
 }
 
 export interface BlogInfo {


### PR DESCRIPTION
## Summary
- 프론트엔드 타입 정의를 백엔드와 일치하도록 수정
- 접근성(a11y) 개선: 키보드 네비게이션, ARIA 속성 추가
- 개발 환경 전용 logger 유틸리티 추가 및 console.error 교체
- 중복 코드 제거 (adminAuth, 상태 중복)
- 포스트 API에 다중 블로그 필터(blog_ids) 지원 (백엔드 + 프론트엔드)
- 로그아웃시 React Query 캐시 클리어
- DB cascade 삭제 및 워커 리소스 관리 개선

## Changes

### Backend
- `Post.blog_id`에 `ondelete="CASCADE"` 추가
- ContentExtractor: Playwright 브라우저 `finally` 블록에서 정리
- RSSCollector: `print` 문을 `logger`로 교체
- 포스트 API (`/api/v1/posts`, `/api/v1/posts/search`)에 `blog_ids` 파라미터 추가
- Elasticsearch `terms` 쿼리로 다중 blog_id 필터링

### Frontend
- 타입 정의 수정: `BlogStatus`, `BlogType`, `PostStatus` enum 사용
- `PostCard`, `blog-filter`: 키보드 네비게이션, ARIA 속성, `loading="lazy"` 추가
- `logger` 유틸리티: 개발 환경에서만 콘솔 출력
- `client.ts`: 중복 `adminAuth` 제거
- `home-client.tsx`: `selectedBlogs` 상태 중복 제거
- `admin/layout.tsx`: 로그아웃시 `queryClient.clear()` 호출
- `useInfinitePosts`: 검색/목록 조회시 `blog_ids` 전달

## Test plan
- [ ] 프론트엔드 빌드 확인 (`npm run build`)
- [ ] 블로그 필터 다중 선택 후 검색 API 요청 확인
- [ ] 블로그 필터 다중 선택 후 목록 API 요청 확인
- [ ] 키보드로 PostCard 네비게이션 확인 (Tab, Enter)
- [ ] 로그아웃 후 재로그인시 이전 데이터 노출 안됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)